### PR TITLE
Move API notes section to IDL comments

### DIFF
--- a/spec_template.md
+++ b/spec_template.md
@@ -51,19 +51,13 @@ example code with each description. The general format is:
 
 # Remarks
 <!-- Explanation and guidance that doesn't fit into the Examples
-section.  For example, see the Remarks for the MediaPlayerElement 
-(https://docs.microsoft.com/uwp/api/Windows.UI.Xaml.Controls.MediaPlayerElement#remarks). -->
-
-
-# API Notes
-<!-- Give a one or two line description of each API (type
-and member), or at least the ones that aren't obvious
-from their name.  These descriptions are what show up
-in IntelliSense. -->
-
+section. -->
 
 # API Details
 <!-- The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/) -->
+<!-- For types and members whose functionality isn't clear from the name,
+add a "/// One or two line description" comment above the definition.  This will
+become the IntelliSense text. -->
 
 # Appendix
 <!-- Anything else that you want to write down for posterity, but 

--- a/spec_template.md
+++ b/spec_template.md
@@ -54,10 +54,12 @@ example code with each description. The general format is:
 
 # API Details
 <!-- The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/) -->
+
 <!-- For types and members whose functionality isn't clear from the name,
 add a "/// One or two line description" comment above the definition.
-By practice (not by automation) this will be copied to docs.microsoft.com to the member page
-and IntelliSense text. -->
+In practice (not by automation) this will be copied to docs.microsoft.com to the member page
+and IntelliSense text. For properties, specify the default value of the property if it
+isn't the type's default (for example an int-typed property that doesn't default to zero). -->
 
 # Appendix
 <!-- Anything else that you want to write down for posterity, but 

--- a/spec_template.md
+++ b/spec_template.md
@@ -59,14 +59,18 @@ only when there's a bug in the caller, such as argument exception.  But if for s
 reason it's necessary for a caller to catch an exception from an API, call that
 out with an explanation either here or in the Examples -->
 
+# API Notes
+<!-- Option 1: Give a one or two line description of each API (type
+and member), or at least the ones that aren't obvious
+from their name.  These descriptions are what show up
+in IntelliSense. For properties, specify the default value of the property if it
+isn't the type's default (for example an int-typed property that doesn't default to zero.) -->
+
+<!-- Option 2: Put these descriptions in the below API Details section,
+with a "///" comment above the member or type. -->
+
 # API Details
 <!-- The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/) -->
-
-<!-- For types and members whose functionality isn't clear from the name,
-add a "/// One or two line description" comment above the definition.
-In practice (not by automation) this will be copied to docs.microsoft.com to the member page
-and IntelliSense text. For properties, specify the default value of the property if it
-isn't the type's default (for example an int-typed property that doesn't default to zero). -->
 
 # Appendix
 <!-- Anything else that you want to write down for posterity, but 

--- a/spec_template.md
+++ b/spec_template.md
@@ -50,14 +50,14 @@ example code with each description. The general format is:
 
 
 # Remarks
-<!-- Explanation and guidance that doesn't fit into the Examples
-section. -->
+<!-- Explanation and guidance that doesn't fit into the Examples section. -->
 
 # API Details
 <!-- The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/) -->
 <!-- For types and members whose functionality isn't clear from the name,
-add a "/// One or two line description" comment above the definition.  This will
-become the IntelliSense text. -->
+add a "/// One or two line description" comment above the definition.
+By practice (not by automation) this will be copied to docs.microsoft.com to the member page
+and IntelliSense text. -->
 
 # Appendix
 <!-- Anything else that you want to write down for posterity, but 

--- a/spec_template.md
+++ b/spec_template.md
@@ -44,6 +44,8 @@ example code with each description. The general format is:
   feature explanation,
   example code
   etc.-->
+  
+<!-- Code samples should be in C# and/or C++/WinRT -->
 
 <!-- As an example of this section, see the Examples section for the PasswordBox control 
 (https://docs.microsoft.com/windows/uwp/design/controls-and-patterns/password-box#examples). -->
@@ -51,6 +53,11 @@ example code with each description. The general format is:
 
 # Remarks
 <!-- Explanation and guidance that doesn't fit into the Examples section. -->
+
+<!-- APIs should only throw exceptions in exceptional conditions; basically,
+only when there's a bug in the caller, such as argument exception.  But if for some
+reason it's necessary for a caller to catch an exception from an API, call that
+out with an explanation either here or in the Examples -->
 
 # API Details
 <!-- The exact API, in MIDL3 format (https://docs.microsoft.com/en-us/uwp/midl-3/) -->


### PR DESCRIPTION
Move the one-line descriptions from its own section to be comments in the IDL. 

Also remove the reference in the Remarks section to MediaPlayerElement; it's a bad example.