### PR TITLE
HierarchicalNavigationView: Correcting API Details Section

### DIFF
--- a/active/NavigationView/HierarchicalNav/HierarchicalNavigationView.md
+++ b/active/NavigationView/HierarchicalNav/HierarchicalNavigationView.md
@@ -140,25 +140,6 @@ public sealed partial class HierarchicalNavigationViewDataBinding : Page
     }
 }
 
-public sealed class NavigationViewItemExpandingEventArgs
-{
-    public NavigationViewItemExpandingEventArgs() {}
-    
-    public object ExpandingItem { get; }
-    public NavigationViewItemBase ExpandedItemContainer { get; }
-    public bool IsSettingsInvoked { get; }
-    public NavigationTransitionInfo RecommendedNavigationTransitionInfo { get; }
-}
-
-public sealed class NavigationViewItemCollapsedEventArgs
-{
-    public NavigationViewItemCollapsedEventArgs() {}
-    
-    public object CollapsedItem { get; }
-    public NavigationViewItemBase CollapsedItemContainer { get; }
-    public bool IsSettingsInvoked { get; }
-    public NavigationTransitionInfo RecommendedNavigationTransitionInfo { get; }
-}
 ```
 
 ## Selection
@@ -297,21 +278,25 @@ in IntelliSense. -->
 | Collapse method |  Collapses the specified node in the tree. | Analogous to [TreeView.Collapse](https://docs.microsoft.com/uwp/api/Microsoft.UI.Xaml.Controls.TreeView.Collapse) |
 | Expanding event | Occurs when a node in the tree starts to expand. | Analogous to [TreeView.Expanding](https://docs.microsoft.com/uwp/api/Microsoft.UI.Xaml.Controls.TreeView.Expanding). In order to fill in nodes as they're expanding, set the `HasUnrealizedChildren` property to true, and then add the children during this `Expanding` event. See the TreeView example [fill a node when it's expanding](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/tree-view#fill-a-node-when-its-expanding).|
 | Collapsed event | Occurs when a node in the tree is collapsed. |  Analogous to [TreeView.Collapsed](https://docs.microsoft.com/uwp/api/Microsoft.UI.Xaml.Controls.TreeView.Collapsed) |
+| NavigationViewItemExpandingEventArgs | Provides event data for NavigationView.Expanding event.  | |
+| NavigationViewItemCollapsedEventArgs | Provides event data for NavigationView.Collapsed event.  | |
 
 # API Details
 ```c++
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
-runtimeclass NavigationViewExpandingEventArgs
+runtimeclass NavigationViewItemExpandingEventArgs
 {
     NavigationViewItemBase ExpandingItemContainer { get; };
+    Object ExpandingItem{ get; };
 }
 
-[WUXC_VERSION_PREVIEW]
+[WUXC_VERSION_MUXONLY]
 [webhosthidden]
-runtimeclass NavigationViewCollapsedEventArgs
+runtimeclass NavigationViewItemCollapsedEventArgs
 {
     NavigationViewItemBase CollapsedItemContainer { get; };
+    Object CollapsedItem{ get; };
 }
 
 [WUXC_VERSION_RS3]


### PR DESCRIPTION
In the previous version of this API spec, I had misplaced the NavigationViewItemExpandingEventArgs and NavigationViewItemCollapsedEventArgs - the older versions of these classes (e.g. NavigationViewExpandingEventArgs) were still in the API details section. 

I've updated the API details section to include the correct updated classes, and updated the API Notes section to reflect what these classes represent.

(Found this issue while working on docs - sorry to bring it up after merging.)