### PR TITLE
Archive repository and update README content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Windows UI Library (WinUI) Specs
+# ⚠️ NOTE: ARCHIVED ⚠️
+
+## This Repository is no longer used, the spec process is handled in the main `microsoft-ui-xaml` repository, and is documented here: https://github.com/microsoft/microsoft-ui-xaml/blob/main/specs/public-api-review-process.md
+
+## Tracking project board: https://github.com/orgs/microsoft/projects/1328?pane=info
+
+### Windows UI Library (WinUI) Specs
 
 This repository contains archived and in-progress spec documents for APIs in the Windows UI Library (WinUI):  
 https://github.com/Microsoft/microsoft-ui-xaml


### PR DESCRIPTION
🦙 Updated README to indicate repository is archived and provide links to the main repository and project board.

FYI @kmahone, not sure if I have permissions to archive this repo after on GitHub, but figured I could point folks in the right direction. Added an issue calling this out as well.